### PR TITLE
Avoid clobbering any explicit value set for Websocket[Secure]Port

### DIFF
--- a/mci/model_mattermost_config.go
+++ b/mci/model_mattermost_config.go
@@ -22,6 +22,8 @@ type MattermostConfig struct {
 				  SessionLengthMobileInDays         int `json:"SessionLengthMobileInDays"`
 				  SessionLengthSSOInDays            int `json:"SessionLengthSSOInDays"`
 				  SessionCacheInMinutes             int `json:"SessionCacheInMinutes"`
+				  WebsocketSecurePort				int `json:"WebsocketSecurePort"`
+				  WebsocketPort						int `json:"WebsocketPort"`
 			  } `json:"ServiceSettings"`
 	TeamSettings      struct {
 				  SiteName                  string `json:"SiteName"`


### PR DESCRIPTION
Our Cloud Foundry only supports WebSocket on a specific port. Specifying the port in the config file has no effect because mci clobbers the value. Adding these two lines seems to prevent that and makes it work for us. 
