### PR TITLE
Configure ssl using `AmazonS3SSL` field instead of url scheme.

### DIFF
--- a/fixtures/config-s3-amazon-broker.json
+++ b/fixtures/config-s3-amazon-broker.json
@@ -66,8 +66,9 @@
     "AmazonS3SecretAccessKey": "MGB8A==",
     "AmazonS3Bucket": "service-instance",
     "AmazonS3Region": "",
-    "AmazonS3Endpoint": "https://s3.amazonaws.com",
+    "AmazonS3Endpoint": "s3.amazonaws.com",
     "AmazonS3BucketEndpoint": "",
+    "AmazonS3SSL": true,
     "AmazonS3LocationConstraint": false,
     "AmazonS3LowercaseBucket": false
   },

--- a/fixtures/config-s3.json
+++ b/fixtures/config-s3.json
@@ -66,8 +66,9 @@
     "AmazonS3SecretAccessKey": "MGB8A==",
     "AmazonS3Bucket": "service-instance",
     "AmazonS3Region": "",
-    "AmazonS3Endpoint": "https://p-riakcs.myriak.com",
+    "AmazonS3Endpoint": "p-riakcs.myriak.com",
     "AmazonS3BucketEndpoint": "",
+    "AmazonS3SSL": true,
     "AmazonS3LocationConstraint": false,
     "AmazonS3LowercaseBucket": false
   },

--- a/mci/cloudify_s3.go
+++ b/mci/cloudify_s3.go
@@ -25,11 +25,7 @@ func cloudifyS3(loader loader.Loader, mattermostConfig *MattermostConfig) error 
 		endpoint = DEFAULT_S3_HOST
 		svc.UseSsl = true
 	}
-	if svc.UseSsl {
-		endpoint = "https://" + endpoint
-	} else {
-		endpoint = "http://" + endpoint
-	}
+	mattermostConfig.FileSettings.AmazonS3SSL = svc.UseSsl
 	if svc.Port != 0 {
 		endpoint += ":" + strconv.Itoa(svc.Port)
 	}

--- a/mci/model_mattermost_config.go
+++ b/mci/model_mattermost_config.go
@@ -18,6 +18,7 @@ type FileSettings struct {
 	AmazonS3SecretAccessKey string `json:"AmazonS3SecretAccessKey"`
 	AmazonS3Bucket          string `json:"AmazonS3Bucket"`
 	AmazonS3Endpoint        string `json:"AmazonS3Endpoint"`
+	AmazonS3SSL             bool   `json:"AmazonS3SSL"`
 }
 type LogSettings struct {
 	EnableFile bool `json:"EnableFile"`


### PR DESCRIPTION
Since mattermost uses minio-go to talk to s3 and minio-go always [prepends a scheme](https://github.com/minio/minio-go/blob/b2b132b19af669fd8e6fda68660c2c9d8031398f/utils.go#L81), s3 urls should not include a scheme. Instead, we can configure ssl using the `AmazonS3SSL` field.

cc @mogul 